### PR TITLE
Remove EW lab flag note

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -103,7 +103,7 @@ Known working implementations of the proposal include:
 
  - [Element X iOS]
  - [Element X Android]
- - [Element Web] (under a [lab flag](https://github.com/element-hq/element-web/pull/28615))
+ - [Element Web]
 
 
 🚫 There is no plan to make Element (Classic) iOS/Android Next-gen auth native clients at this time. Instead the focus is on Element X.


### PR DESCRIPTION
This was delabbed on Dec 20, 2024, so this comment can be removed. https://github.com/element-hq/element-web/pull/28615